### PR TITLE
[MySQL] allow users to disable the creation of voicegateway-mysql-password

### DIFF
--- a/templates/common-secrets/voicegateway-mysql-password.yaml
+++ b/templates/common-secrets/voicegateway-mysql-password.yaml
@@ -1,4 +1,4 @@
-{{- if not (lookup "v1" "Secret" $.Release.Namespace "voicegateway-mysql-password") }}
+{{- if and (.Values.mysql.createSecret) (not (lookup "v1" "Secret" $.Release.Namespace "voicegateway-mysql-password")) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/values.yaml
+++ b/values.yaml
@@ -421,6 +421,7 @@ influxdb:
 ## Bitnami Chart, image info: bitnami/mysql:8.0.39-debian-12-r5
 mysql:
   enabled: true
+  createSecret: true
   global:
     imagePullSecrets:
       - cognigy-registry-token


### PR DESCRIPTION
This is needed for when the secret is already created and existing and the chart is not directly applied via helm, but templated and applied using kubectl for example.