### PR TITLE
[MySQL] replace the hardcoded `mysql` host in some templates

### DIFF
--- a/templates/feature-server/deployment.yaml
+++ b/templates/feature-server/deployment.yaml
@@ -70,7 +70,7 @@ spec:
             - sh 
             - -c 
             - |
-              until mysql -u {{ .Values.mysql.auth.username }} -D {{ .Values.mysql.database.name }} -h mysql -p${PASSWORD} --protocol=tcp -e "select count(*) from accounts";
+              until mysql -u {{ .Values.mysql.auth.username }} -D {{ .Values.mysql.database.name }} -h {{ .Values.mysql.host }} -p${PASSWORD} --protocol=tcp -e "select count(*) from accounts";
               do 
                 sleep 5
               done

--- a/templates/feature-server/stateful-set.yaml
+++ b/templates/feature-server/stateful-set.yaml
@@ -71,7 +71,7 @@ spec:
             - sh 
             - -c 
             - |
-              until mysql -u {{ .Values.mysql.auth.username }} -D {{ .Values.mysql.database.name }} -h mysql -p${PASSWORD} --protocol=tcp -e "select count(*) from accounts";
+              until mysql -u {{ .Values.mysql.auth.username }} -D {{ .Values.mysql.database.name }} -h {{ .Values.mysql.host }} -p${PASSWORD} --protocol=tcp -e "select count(*) from accounts";
               do 
                 sleep 5
               done

--- a/templates/sbc-rtp/daemon-set.yaml
+++ b/templates/sbc-rtp/daemon-set.yaml
@@ -70,7 +70,7 @@ spec:
             - sh 
             - -c 
             - |
-              until mysql -u {{ .Values.mysql.auth.username }} -D {{ .Values.mysql.database.name }} -h mysql -p${PASSWORD} --protocol=tcp -e "select count(*) from accounts";
+              until mysql -u {{ .Values.mysql.auth.username }} -D {{ .Values.mysql.database.name }} -h {{ .Values.mysql.host }} -p${PASSWORD} --protocol=tcp -e "select count(*) from accounts";
               do 
                 sleep 5
               done

--- a/templates/sbc-rtp/stateful-set.yaml
+++ b/templates/sbc-rtp/stateful-set.yaml
@@ -72,7 +72,7 @@ spec:
             - sh 
             - -c 
             - |
-              until mysql -u {{ .Values.mysql.auth.username }} -D {{ .Values.mysql.database.name }} -h mysql -p${PASSWORD} --protocol=tcp -e "select count(*) from accounts";
+              until mysql -u {{ .Values.mysql.auth.username }} -D {{ .Values.mysql.database.name }} -h {{ .Values.mysql.host }} -p${PASSWORD} --protocol=tcp -e "select count(*) from accounts";
               do 
                 sleep 5
               done

--- a/templates/sbc-sip/daemon-set.yaml
+++ b/templates/sbc-sip/daemon-set.yaml
@@ -105,7 +105,7 @@ spec:
             - sh 
             - -c 
             - |
-              until mysql -u {{ .Values.mysql.auth.username }} -D {{ .Values.mysql.database.name }} -h mysql -p${PASSWORD} --protocol=tcp -e "select count(*) from accounts";
+              until mysql -u {{ .Values.mysql.auth.username }} -D {{ .Values.mysql.database.name }} -h {{ .Values.mysql.host }} -p${PASSWORD} --protocol=tcp -e "select count(*) from accounts";
               do 
                 sleep 5
               done

--- a/templates/sbc-sip/stateful-set.yaml
+++ b/templates/sbc-sip/stateful-set.yaml
@@ -107,7 +107,7 @@ spec:
             - sh 
             - -c 
             - |
-              until mysql -u {{ .Values.mysql.auth.username }} -D {{ .Values.mysql.database.name }} -h mysql -p${PASSWORD} --protocol=tcp -e "select count(*) from accounts";
+              until mysql -u {{ .Values.mysql.auth.username }} -D {{ .Values.mysql.database.name }} -h {{ .Values.mysql.host }} -p${PASSWORD} --protocol=tcp -e "select count(*) from accounts";
               do 
                 sleep 5
               done


### PR DESCRIPTION
This is needed for when the MySQL host is an external instance. The init-container of `feature-server` is waiting forever for a hardcoded host named `mysql`.