### PR TITLE
fix: use image.pullSecrets instead of hardcoded imagePullSecret

### DIFF
--- a/templates/api-ban/cronjob.yaml
+++ b/templates/api-ban/cronjob.yaml
@@ -17,6 +17,7 @@ spec:
             checksum/cognigy-env: {{ include (print $.Template.BasePath "/configurations/cognigy-env.yaml") $ | sha256sum }}
         spec:
           containers:
+            {{- include "image.pullSecrets" $ | nindent 10 }}
             - name: api-ban
               image: {{ include "vg.common.image.render" (dict "global" $.Values.global "image" .Values.apiBan.image) }}
               imagePullPolicy: {{ .Values.apiBan.imagePullPolicy }}
@@ -41,6 +42,4 @@ spec:
                 - configMapRef:
                     name: cognigy-env
           restartPolicy: Never
-          imagePullSecrets:
-            - name: cognigy-registry-token
 {{- end }}

--- a/templates/billing-app/cronjob.yaml
+++ b/templates/billing-app/cronjob.yaml
@@ -11,6 +11,7 @@ spec:
       ttlSecondsAfterFinished: {{ .Values.billingApp.callHistoryTtlSecondsAfterFinished }}
       template:
         spec:
+          {{- include "image.pullSecrets" $ | nindent 10 }}
           containers:
             - name: update-call-history
               image: {{ include "vg.common.image.render" (dict "global" $.Values.global "image" .Values.jobs.image) }}
@@ -36,6 +37,4 @@ spec:
                 - -c
                 - "curl -X POST $URL -H 'x-api-key: '$API_KEY'' -H 'Content-Type: application/json' -d '{\"timestamp\": '$(date -d '-1 hour' +%s)'}'"
           restartPolicy: Never
-          imagePullSecrets:
-            - name: cognigy-registry-token
 {{- end }}

--- a/templates/billing-app/deactivate-cron.yaml
+++ b/templates/billing-app/deactivate-cron.yaml
@@ -11,6 +11,7 @@ spec:
       ttlSecondsAfterFinished: {{ .Values.billingApp.deactivateTtlSecondsAfterFinished }}
       template:
         spec:
+          {{- include "image.pullSecrets" $ | nindent 10 }}
           containers:
             - name: deactivate-account-billing
               image: {{ include "vg.common.image.render" (dict "global" $.Values.global "image" .Values.jobs.image) }}
@@ -36,6 +37,4 @@ spec:
                 - -c
                 - "curl -X POST $URL -H 'x-api-key: '$API_KEY'' -H 'Content-Type: application/json' -d '{\"timestamp\": '$(date +%s)'}'"
           restartPolicy: Never
-          imagePullSecrets:
-            - name: cognigy-registry-token
 {{- end }}

--- a/templates/test-call-manager/cronjob.yaml
+++ b/templates/test-call-manager/cronjob.yaml
@@ -11,6 +11,7 @@ spec:
       ttlSecondsAfterFinished: {{ .Values.testCallManager.cronjobTtlSecondsAfterFinished }}
       template:
         spec:
+          {{- include "image.pullSecrets" $ | nindent 10 }}
           containers:
           - name: clean-up
             image: {{ include "vg.common.image.render" (dict "global" $.Values.global "image" .Values.jobs.image) }}
@@ -32,6 +33,4 @@ spec:
               - -c
               - "curl -X DELETE $URL -H 'x-api-key: '$API_KEY'' -H 'Content-Type: application/json' -d '{\"timestamp\": '$(date +%s000)'}'"
           restartPolicy: Never
-          imagePullSecrets:
-            - name: cognigy-registry-token
 {{- end }}


### PR DESCRIPTION
Cronjobs will fail, because a hardcoded imagePullSecret `cognigy-registry-token` may be missing, so use the template ` image.pullSecret` instead of hardcoded imagePullSecret `cognigy-registry-token`.