### PR TITLE
fix: always generate IpWhitelist middleware when ingress is enabled

### DIFF
--- a/templates/homer/ingress.yaml
+++ b/templates/homer/ingress.yaml
@@ -11,6 +11,12 @@ metadata:
     {{- else }}
     traefik.ingress.kubernetes.io/router.entrypoints: web
     {{- end }}
+    {{- if .Values.ingress.homer.ipWhiteListMiddleware.enabled }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ $.Release.Namespace }}-ipwhitelisthomer@kubernetescrd
+    {{- end }}
+    {{- if .Values.ingress.homer.basicAuthMiddleware.enabled }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ $.Release.Namespace }}-homerauth@kubernetescrd
+    {{- end }}
   {{- end }}
   {{- if .Values.ingress.homer.extraAnnotations }}
     {{- include "vg.common.tplvalues.render" (dict "value" .Values.ingress.homer.extraAnnotations "context" $) | nindent 4 }}

--- a/templates/middleware/ipwhitelist-api-server.yaml
+++ b/templates/middleware/ipwhitelist-api-server.yaml
@@ -1,11 +1,11 @@
-{{- if and (.Values.ingress.enabled) (.Values.traefik.enabled) (.Values.ingress.webapp.ipWhiteListMiddleware.enabled) }}
-{{- with .Values.ingress.webapp.ipWhiteListMiddleware }}
+{{- if and (.Values.ingress.enabled) (.Values.ingress.api.ipWhiteListMiddleware.enabled) }}
+{{- with .Values.ingress.api.ipWhiteListMiddleware }}
 ---
 # Whitelisting Based on `X-Forwarded-For` with `depth=0`
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: ipwhitelistwebapp
+  name: ipwhitelistapiserver
   namespace: {{ $.Release.Namespace | quote }}
 spec:
   ipAllowList: {{- toYaml .ipWhiteList | nindent 4 }}

--- a/templates/middleware/ipwhitelist-billing-app.yaml
+++ b/templates/middleware/ipwhitelist-billing-app.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.ingress.enabled) (.Values.traefik.enabled) (.Values.ingress.billingApp.ipWhiteListMiddleware.enabled) }}
+{{- if and (.Values.ingress.enabled) (.Values.ingress.billingApp.ipWhiteListMiddleware.enabled) }}
 {{- with .Values.ingress.billingApp.ipWhiteListMiddleware }}
 ---
 # Whitelisting Based on `X-Forwarded-For` with `depth=0`

--- a/templates/middleware/ipwhitelist-homer.yaml
+++ b/templates/middleware/ipwhitelist-homer.yaml
@@ -1,0 +1,13 @@
+{{- if and (.Values.ingress.enabled) (.Values.ingress.homer.enabled) (.Values.ingress.homer.ipWhiteListMiddleware.enabled) }}
+{{- with .Values.ingress.homer.ipWhiteListMiddleware }}
+---
+# Whitelisting Based on `X-Forwarded-For` with `depth=0`
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: ipwhitelisthomer
+  namespace: {{ $.Release.Namespace | quote }}
+spec:
+  ipAllowList: {{- toYaml .ipWhiteList | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/templates/middleware/ipwhitelist-jaeger.yaml
+++ b/templates/middleware/ipwhitelist-jaeger.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.ingress.enabled) (.Values.ingress.jaeger.ipWhiteListMiddleware.enabled) }}
+{{- if and (.Values.ingress.enabled) (.Values.ingress.jaeger.enabled) (.Values.ingress.jaeger.ipWhiteListMiddleware.enabled) }}
 {{- with .Values.ingress.jaeger.ipWhiteListMiddleware }}
 ---
 # Whitelisting Based on `X-Forwarded-For` with `depth=0`

--- a/templates/middleware/ipwhitelist-jaeger.yaml
+++ b/templates/middleware/ipwhitelist-jaeger.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.ingress.enabled) (.Values.traefik.enabled) (.Values.ingress.jaeger.ipWhiteListMiddleware.enabled) }}
+{{- if and (.Values.ingress.enabled) (.Values.ingress.jaeger.ipWhiteListMiddleware.enabled) }}
 {{- with .Values.ingress.jaeger.ipWhiteListMiddleware }}
 ---
 # Whitelisting Based on `X-Forwarded-For` with `depth=0`

--- a/templates/middleware/ipwhitelist-test-call-manager.yaml
+++ b/templates/middleware/ipwhitelist-test-call-manager.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.ingress.enabled) (.Values.traefik.enabled) (.Values.ingress.testCallManager.ipWhiteListMiddleware.enabled) }}
+{{- if and (.Values.ingress.enabled) (.Values.ingress.testCallManager.ipWhiteListMiddleware.enabled) }}
 {{- with .Values.ingress.testCallManager.ipWhiteListMiddleware }}
 ---
 # Whitelisting Based on `X-Forwarded-For` with `depth=0`

--- a/templates/middleware/ipwhitelist-webapp.yaml
+++ b/templates/middleware/ipwhitelist-webapp.yaml
@@ -1,11 +1,11 @@
-{{- if and (.Values.ingress.enabled) (.Values.traefik.enabled) (.Values.ingress.api.ipWhiteListMiddleware.enabled) }}
-{{- with .Values.ingress.api.ipWhiteListMiddleware }}
+{{- if and (.Values.ingress.enabled) (.Values.ingress.webapp.ipWhiteListMiddleware.enabled) }}
+{{- with .Values.ingress.webapp.ipWhiteListMiddleware }}
 ---
 # Whitelisting Based on `X-Forwarded-For` with `depth=0`
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: ipwhitelistapiserver
+  name: ipwhitelistwebapp
   namespace: {{ $.Release.Namespace | quote }}
 spec:
   ipAllowList: {{- toYaml .ipWhiteList | nindent 4 }}


### PR DESCRIPTION
always generate middleware for ipwhitelisting if ingress is enabled, because otherweise th ingresses reference whitelist middlewares that does not exist

also: fix file names from `ipwhilelist-.*` to `ipwhitelist-.*`