### PR TITLE
fix: replace hardcoded postgresql hostname & port by the values from …

### DIFF
--- a/templates/heplify-server/config-map.yaml
+++ b/templates/heplify-server/config-map.yaml
@@ -23,7 +23,7 @@ data:
     PromTargetName        = ""
     DBShema               = "homer7"
     DBDriver              = "postgres"
-    DBAddr                = "postgres:5432"
+    DBAddr                = {{ printf "%s:%d" .Values.postgresql.host (.Values.postgresql.port | int) | quote }}
     DBDataTable           = "homer_data"
     DBConfTable           = "homer_config"
     DBUser                = {{ .Values.postgresql.auth.postgresUsername | quote }}

--- a/templates/homer/config-map.yaml
+++ b/templates/homer/config-map.yaml
@@ -17,7 +17,7 @@ data:
       },
       "database_config": {
         "help": "Settings for PostgreSQL Database (settings)",
-        "host": "postgres",
+        "host": {{ .Values.postgresql.host | quote }},
         "keepalive": true,
         "name": "homer_config",
         "node": "LocalConfig",
@@ -27,7 +27,7 @@ data:
       "database_data": {
         "localnode": {
           "help": "Settings for PostgreSQL Database (data)",
-          "host": "postgres",
+          "host": {{ .Values.postgresql.host | quote }},
           "keepalive": true,
           "name": "homer_data",
           "node": "LocalNode",

--- a/values.yaml
+++ b/values.yaml
@@ -466,6 +466,8 @@ mysql:
 ## Bitnami Chart, image info: bitnami/postgresql:14.12.0-debian-12-r15
 ## Used only internally by heplify-server and homer to store sip captures
 postgresql:
+  ## if enabled: false, only the deployment will be disabled
+  ## values as host & port may still be used in config for homer & heplify-server
   enabled: true
   replicaCount: 1
   global:


### PR DESCRIPTION
…values.yaml (and their defaults)

topic says it all, please, please, please do not ever use any hardcoded hostnames, databases names or similar.

Thank you!