### PR TITLE
Enable rtpengine --listen-cli for sidecar CLI-stats poller

### DIFF
--- a/templates/sbc-rtp/daemon-set.yaml
+++ b/templates/sbc-rtp/daemon-set.yaml
@@ -89,10 +89,11 @@ spec:
             - name: rtp-engine
               containerPort: {{ .Values.rtpEngine.port }}
               protocol: TCP            
-          args: 
+          args:
             - rtpengine
             - --listen-udp=22222
             - --listen-http=0.0.0.0:22222
+            - --listen-cli=127.0.0.1:9900
             - --port-min={{ .Values.rtpEngine.startPort }}
             - --port-max={{ .Values.rtpEngine.endPort }}
             - --homer

--- a/templates/sbc-rtp/stateful-set.yaml
+++ b/templates/sbc-rtp/stateful-set.yaml
@@ -118,6 +118,7 @@ spec:
               exec /entrypoint.sh rtpengine \
                 --listen-udp=22222 \
                 --listen-http=0.0.0.0:22222 \
+                --listen-cli=127.0.0.1:9900 \
                 --port-min={{ .Values.rtpEngine.startPort }} \
                 --port-max={{ .Values.rtpEngine.endPort }} \
                 --homer {{ .Values.heplifyServer.serviceName }}:{{ .Values.heplifyServer.ports.udp }} \
@@ -125,10 +126,11 @@ spec:
                 --homer-id {{ .Values.rtpEngine.homerId | quote }} \
                 --log-level {{ if .Values.rtpEngine.logLevel }}{{ .Values.rtpEngine.logLevel | quote }}{{ else }}{{ .Values.global.logLevel | quote }}{{ end }}
           {{- else }}
-          args: 
+          args:
             - rtpengine
             - --listen-udp=22222
             - --listen-http=0.0.0.0:22222
+            - --listen-cli=127.0.0.1:9900
             - --port-min={{ .Values.rtpEngine.startPort }}
             - --port-max={{ .Values.rtpEngine.endPort }}
             - --homer


### PR DESCRIPTION
## Summary
- Adds `--listen-cli=127.0.0.1:9900` to the `rtp-engine` container args in `templates/sbc-rtp/stateful-set.yaml` (both the default and `stackit`-cloud branches) and `templates/sbc-rtp/daemon-set.yaml`.

## Why
[Cognigy/vg-sbc-rtpengine-sidecar#20](https://github.com/Cognigy/vg-sbc-rtpengine-sidecar/pull/20) adds a poller in the sidecar that connects to rtpengine's own CLI interface on loopback (`127.0.0.1:9900`) and mirrors its `list totals` output (session timeout/termination breakdowns, MOS, jitter, packet loss, uptime) as `sbc_rtpengine_stats_*` Prometheus gauges. rtpengine only opens that TCP listener when `--listen-cli` is explicitly passed on the command line — it wasn't set anywhere in this chart, so without this change the poller gets `ECONNREFUSED` on every tick and every one of those gauges stays at 0/missing in production.

This is loopback-only (`127.0.0.1`), so it isn't reachable outside the pod and doesn't need a Service/port entry.

## Test plan
- [x] `helm dependency build` + `helm template` rendered `templates/sbc-rtp/stateful-set.yaml` (default cloud and `cloud=stackit` branches) and `templates/sbc-rtp/daemon-set.yaml` — confirmed `--listen-cli=127.0.0.1:9900` appears correctly in all three rendered variants
- [x] `helm lint` passes
- [ ] Deploy to a non-prod environment alongside vg-sbc-rtpengine-sidecar#20 and confirm `sbc_rtpengine_stats_*` gauges populate on `:8002/metrics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)